### PR TITLE
Add warning about vtex validate deprecation

### DIFF
--- a/docs/2019-week-47-48-49-50-51/publish-command.md
+++ b/docs/2019-week-47-48-49-50-51/publish-command.md
@@ -7,6 +7,8 @@ git: "https://github.com/vtex-apps/release-notes/blob/master/docs/2019-week-47-4
 
 # Publish command
 
+:warning: Updated January 13, 2020: `vtex validate` command is deprecated. Use `vtex deploy` instead.
+
 The `vtex publish` command, responsible for publishing new app versions, will change its platform behavior on 01/02/2020.
 
 :warning: This release is merely a notice about the impending change to the app publishing process, meaning that **this release is not yet live** and **will only be in effect as of January 2, 2020**. 


### PR DESCRIPTION
`vtex validate` command was deprecated in favor of `vtex deploy`. We added a disclaimer to the release in order to make our communication consistent.